### PR TITLE
Environment Variable Support

### DIFF
--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -37,7 +37,7 @@ def get_config_dir_path(config_path: str) -> str:
         config_path = os.path.join(path_from_main, config_path)
     return config_path
 
-def unlock(config_name: str, config_path: Optional[str] = None, bind_env_vars: Optional[bool] = False) -> Callable:
+def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
     """
     Create a decorator for parsing and injecting configuration arguments into a
     main function from a YAML file.
@@ -65,10 +65,12 @@ def unlock(config_name: str, config_path: Optional[str] = None, bind_env_vars: O
         def _inner_function():
             parser = argparse.ArgumentParser()
             add_args_from_dict(parser, config)
-            if bind_env_vars:
-                # Inject environment variables into the parser if they are also defined in the config
-                for env, val in ((e,v) for e,v in dict(os.environ).items() if f'--{e.lower()}' in parser._option_string_actions):
-                    parser._option_string_actions[f'--{env.lower()}'].default = val
+            for action in parser._option_string_actions.values():
+                action_name = action.dest
+                if action_name.startswith('$') and action_name[1:] in os.environ:
+                    action.default = os.environ[action_name[1:]]
+
+
             args = parser.parse_args()
             args = namespace_to_nested_namespace(args)
             main(args)

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -6,7 +6,6 @@ import sys
 from typing import Callable, Optional, Type, Any, Dict
 
 from .config import load_yaml_config, add_args_from_dict, add_yaml_extension, namespace_to_nested_namespace
-import pprint
 
 def get_config_dir_path(config_path: str) -> str:
     """

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -6,7 +6,7 @@ import sys
 from typing import Callable, Optional, Type, Any, Dict
 
 from .config import load_yaml_config, add_args_from_dict, add_yaml_extension, namespace_to_nested_namespace
-
+import pprint
 
 def get_config_dir_path(config_path: str) -> str:
     """
@@ -65,7 +65,11 @@ def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
         @functools.wraps(main)
         def _inner_function():
             parser = argparse.ArgumentParser()
+            # Inject args from YAML config
             add_args_from_dict(parser, config)
+            # Inject environment variables into the parser if they are also defined in the config
+            for env, val in ((e,v) for e,v in dict(os.environ).items() if f'--{e.lower()}' in parser._option_string_actions):
+                parser._option_string_actions[f'--{env.lower()}'].default = val
             args = parser.parse_args()
             args = namespace_to_nested_namespace(args)
             main(args)

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -37,7 +37,7 @@ def get_config_dir_path(config_path: str) -> str:
         config_path = os.path.join(path_from_main, config_path)
     return config_path
 
-def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
+def unlock(config_name: str, config_path: Optional[str] = None, bind_env_vars: Optional[bool] = False) -> Callable:
     """
     Create a decorator for parsing and injecting configuration arguments into a
     main function from a YAML file.
@@ -65,9 +65,10 @@ def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
         def _inner_function():
             parser = argparse.ArgumentParser()
             add_args_from_dict(parser, config)
-            # Inject environment variables into the parser if they are also defined in the config
-            for env, val in ((e,v) for e,v in dict(os.environ).items() if f'--{e.lower()}' in parser._option_string_actions):
-                parser._option_string_actions[f'--{env.lower()}'].default = val
+            if bind_env_vars:
+                # Inject environment variables into the parser if they are also defined in the config
+                for env, val in ((e,v) for e,v in dict(os.environ).items() if f'--{e.lower()}' in parser._option_string_actions):
+                    parser._option_string_actions[f'--{env.lower()}'].default = val
             args = parser.parse_args()
             args = namespace_to_nested_namespace(args)
             main(args)

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -65,7 +65,6 @@ def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
         @functools.wraps(main)
         def _inner_function():
             parser = argparse.ArgumentParser()
-            # Inject args from YAML config
             add_args_from_dict(parser, config)
             # Inject environment variables into the parser if they are also defined in the config
             for env, val in ((e,v) for e,v in dict(os.environ).items() if f'--{e.lower()}' in parser._option_string_actions):


### PR DESCRIPTION
This implements basic support for environment variables as seen in #2 . `skeletonkey.unlock()` now has a `bind_env_var` parameter that enables the binding of environment variables to skeletonkey config file options. If `bind_env_var` is true and there is an environment variable with the same (lowercased) name as a config option, its value will be bound to that option's value.

The new order of precedence would be as follows, from highest at the top to lowest at the bottom:
 - Command line flag
 - Environment variable
 - Config file

**Note:** This current method may cause issues if there are options that have been defined in the config file that happen to also be environment variables. To solve this, one option could be to change `bind_env_var` from a bool to a list of strings defining the names of specific environment variables that should be bound.