### PR TITLE
Added extra config file syntax to set certain variables as boolean command line flags

### DIFF
--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -246,6 +246,10 @@ def add_args_from_dict(
                 arg_parser.add_argument(
                     f"--{prefix}{key[1:]}", default=env_var, type=type(env_var)
                 )
+            elif key.startswith("?"):
+                arg_parser.add_argument(
+                    f"--{prefix}{key[1:]}", default=value, action='store_true'
+                        )
             else:
                 arg_parser.add_argument(
                     f"--{prefix}{key}", default=value, type=type(value)


### PR DESCRIPTION
This PR enables users to define variables as boolean flags by placing a `?` before the variable definition in the config file. This is meant to be similar in function as using `$` for binding config variables to environment variables.

# Example
## Before
**config.yaml**
```yaml
debug: False
```

```
> main.py --debug True
```

## After
**config.yaml**
```yaml
?debug: False
```

```
> main.py --debug
```