### PR TITLE
Removed $'s from variable names bound with environment variables when the environment var doesn't exist

### DIFF
--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -241,10 +241,11 @@ def add_args_from_dict(
         if isinstance(value, dict):
             add_args_from_dict(arg_parser, value, f"{prefix}{key}.")
         else:
-            if key.startswith("$") and key[1:] in os.environ:
-                env_var = os.environ[key[1:]]
+            if key.startswith("$"):
+                if key[1:] in os.environ:
+                    value = os.environ[key[1:]]
                 arg_parser.add_argument(
-                    f"--{prefix}{key[1:]}", default=env_var, type=type(env_var)
+                    f"--{prefix}{key[1:]}", default=value, type=type(value)
                 )
             else:
                 arg_parser.add_argument(


### PR DESCRIPTION
Previously, using the `$` syntax to bind config variables to environment variables would leave the $ character in the variable name if an environment variable of the same name didn't exist. This meant you had to write `args.$ENV_VAR` to access it in python or `main.py --$ENV_VAR` to access it through the command line flags. This PR fixes the issue by ensuring variables beginning with $ are always parsed correctly even when the associated environment variable doesn't currently exist.