### PR TITLE
Added support for config collections.

### DIFF
--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -171,7 +171,7 @@ def get_default_args_from_path(config_path: str, default_yaml: str) -> dict:
 
 
 def load_yaml_config(
-    config_path: str, config_name: str, default_keyword: str = "defaults"
+    config_path: str, config_name: str, default_keyword: str = "defaults", collection_keyword: str = "keyring"
 ) -> dict:
     """
     Load a YAML configuration file and update it with default configurations.
@@ -219,6 +219,20 @@ def load_yaml_config(
                     )
         del config[default_keyword]
 
+    if collection_keyword in config:
+        collections_dict = config[collection_keyword]
+        for collection_key in collections_dict.keys():
+
+            if collection_key in config:
+                return ValueError("You cannot have a collection with the same name as an argument.")
+
+            collection_dict = collections_dict[collection_key]
+            config[collection_key] = {}
+            for subconfig_key in collection_dict.keys():
+                subconfig = get_default_args_from_path(config_path, collection_dict[subconfig_key])
+                config[collection_key].update({subconfig_key : subconfig})
+        del config[collection_keyword]
+    
     return config
 
 

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -74,7 +74,7 @@ def unlock(config_name: str, config_path: Optional[str] = None) -> Callable:
             add_args_from_dict(parser, config)
             args = parser.parse_args()
             args = namespace_to_nested_namespace(args)
-            main(args)
+            return main(args)
 
         return _inner_function
 


### PR DESCRIPTION
This adds support to have configuration collections. You must use the "keyring" keyword to indicate you want to load a subconfig.

```yaml
keyring:
    models:
        - model1: /path/to/subconfig1.yaml
        - model2: /path/to/subconfig2.yaml
```

All of the config arguments found in subconfig,yaml can be accessed like this:

```python
subconfig1_args = args.models.model1
```