### PR TITLE
Implemented recursive initialization for sub-targets

### DIFF
--- a/example/recursive_target_example/config.yaml
+++ b/example/recursive_target_example/config.yaml
@@ -1,0 +1,12 @@
+a_obj:
+  _target_: "main.A"
+  a_arg: 10
+  b_obj:
+    _target_: "main.B"
+    b_arg: 20
+    c_obj1:
+      _target_: "main.C"
+      c_arg: 30
+    c_obj2:
+      _target_: "main.C"
+      c_arg: 40

--- a/example/recursive_target_example/main.py
+++ b/example/recursive_target_example/main.py
@@ -1,0 +1,38 @@
+import skeletonkey
+
+
+class C:
+    def __init__(self, c_arg: int):
+        self.c_arg: int = c_arg
+        
+class B:
+    def __init__(self, b_arg: int, c_obj1: C, c_obj2: C):
+        self.b_arg: int = b_arg
+        self.c_obj1: C = c_obj1
+        self.c_obj2: C = c_obj2
+
+class A:
+    def __init__(self, a_arg: int, b_obj: B):
+        self.a_arg: int = a_arg
+        self.b_obj: B = b_obj
+
+
+@skeletonkey.unlock("config.yaml")
+def main(args):
+    a_obj = skeletonkey.instantiate(args.a_obj)
+    
+    print("a_obj: ", "\n",
+          "\targ: ", a_obj.a_arg, "\n",
+          
+          "\tb_obj: ", "\n",
+          "\t\targ: ", a_obj.b_obj.b_arg, "\n",
+          
+          "\t\tc_obj1: ",  "\n"
+          "\t\t\targ: ", a_obj.b_obj.c_obj1.c_arg, "\n",
+          
+          "\t\tc_obj2: ", "\n",
+          "\t\t\targ: ", a_obj.b_obj.c_obj2.c_arg, sep="")
+          
+
+if __name__ == "__main__":  
+    main()

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -103,7 +103,7 @@ def import_class(class_string: str) -> Type[Any]:
     return class_obj
 
 
-def instantiate(config: Config, target_keyword=TARGET_KEYWORD, **kwargs) -> Any:
+def instantiate(config: Config, target_keyword=TARGET_KEYWORD, _instantiate_recursive=True, **kwargs) -> Any:
     """
     Instantiate a class object using a Config object.
     The Config object should contain the key "_target_" to
@@ -123,6 +123,11 @@ def instantiate(config: Config, target_keyword=TARGET_KEYWORD, **kwargs) -> Any:
     obj_kwargs = vars(config).copy()
     class_obj = import_class(obj_kwargs[target_keyword])
     del obj_kwargs[target_keyword]
+
+    if _instantiate_recursive:
+        for k, v in obj_kwargs.items():
+            if isinstance(v, Config) and (target_keyword in vars(v)):
+                obj_kwargs[k] = instantiate(v)
 
     obj_kwargs.update(kwargs)
 


### PR DESCRIPTION
Related to issue #20 (Recursive initialization: Having sub-_targets_ for initialize objects as arguments for other objects)

During instantiation, if any of the values in the Config being instantiated are themselves Configs **and** contain the _target_ keyword, that sub-config would also be instantiated and would take the place of that value in the super-config for that key.

Also included in this PR is an example case that demonstrates this behavior and acts as a basic test case.