### PR TITLE
Update the sys.path of the example files to run the local version of the repository.

### DIFF
--- a/example/basic_example/main.py
+++ b/example/basic_example/main.py
@@ -1,3 +1,7 @@
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
 import skeletonkey
 
 class MyModel:

--- a/example/defaults_example/main.py
+++ b/example/defaults_example/main.py
@@ -1,4 +1,7 @@
-import skeletonkey
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
 
 @skeletonkey.unlock("config.yaml")
 def main(args):

--- a/example/defaults_example/main.py
+++ b/example/defaults_example/main.py
@@ -2,6 +2,7 @@
 import os, sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
 
+import skeletonkey
 
 @skeletonkey.unlock("config.yaml")
 def main(args):

--- a/example/keyring_example/main.py
+++ b/example/keyring_example/main.py
@@ -1,4 +1,7 @@
-import skeletonkey
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
 
 class MyModel:
     def __init__(self, layer_size: int, activation: str) -> None:

--- a/example/keyring_example/main.py
+++ b/example/keyring_example/main.py
@@ -2,6 +2,7 @@
 import os, sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
 
+import skeletonkey
 
 class MyModel:
     def __init__(self, layer_size: int, activation: str) -> None:

--- a/example/recursive_target_example/main.py
+++ b/example/recursive_target_example/main.py
@@ -1,5 +1,8 @@
-import skeletonkey
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
 
+import skeletonkey
 
 class C:
     def __init__(self, c_arg: int):


### PR DESCRIPTION
This change is simply to add a few lines at the top of the example main.py files so that the local skeletonkey repo is imported rather than the global one installed with pip.

The justification for this change is so that the example files can be used as basic tests of the current functionality during development, reflecting the more up-to-date version of the code. 