### PR TITLE
Rework defaults with profiles and easier command-line specification

### DIFF
--- a/example/defaults_example/config.yaml
+++ b/example/defaults_example/config.yaml
@@ -1,3 +1,3 @@
-defaults:
+profiles:
   - subconfigs/default_config1.yaml
   - subconfigs/default_config2.yaml

--- a/example/profiles_example/config.yaml
+++ b/example/profiles_example/config.yaml
@@ -1,0 +1,15 @@
+profiles:
+  
+  ~train:
+    default: defaults/train.yaml
+    model:
+      head: models/train/head.yaml
+      backbone: models/train/backbone.yaml
+    dataset: datasets/train_dataset.yaml
+  
+  debug:
+    default: defaults/debug.yaml
+    model:
+      head: models/debug/head.yaml
+      backbone: models/debug/backbone.yaml
+    dataset: datasets/debug_dataset.yaml

--- a/example/profiles_example/datasets/debug_dataset.yaml
+++ b/example/profiles_example/datasets/debug_dataset.yaml
@@ -1,0 +1,2 @@
+dataset:
+  _target_: datasets.debug_dataset

--- a/example/profiles_example/datasets/train_dataset.yaml
+++ b/example/profiles_example/datasets/train_dataset.yaml
@@ -1,0 +1,2 @@
+dataset:
+  _target_: datasets.dataset

--- a/example/profiles_example/defaults/debug.yaml
+++ b/example/profiles_example/defaults/debug.yaml
@@ -1,0 +1,1 @@
+mode: debug

--- a/example/profiles_example/defaults/train.yaml
+++ b/example/profiles_example/defaults/train.yaml
@@ -1,0 +1,1 @@
+mode: train

--- a/example/profiles_example/main.py
+++ b/example/profiles_example/main.py
@@ -1,0 +1,13 @@
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
+import skeletonkey
+
+
+@skeletonkey.unlock("config.yaml")
+def main(args):
+    print(args)
+
+if __name__ == "__main__":  
+    main()

--- a/example/profiles_example/models/debug/backbone.yaml
+++ b/example/profiles_example/models/debug/backbone.yaml
@@ -1,0 +1,2 @@
+backbone_model:
+  _target_: models.debug_backbone

--- a/example/profiles_example/models/debug/head.yaml
+++ b/example/profiles_example/models/debug/head.yaml
@@ -1,0 +1,2 @@
+head_model:
+  _target_: models.debug_head

--- a/example/profiles_example/models/train/backbone.yaml
+++ b/example/profiles_example/models/train/backbone.yaml
@@ -1,0 +1,2 @@
+backbone_model:
+  _target_: models.backbone

--- a/example/profiles_example/models/train/head.yaml
+++ b/example/profiles_example/models/train/head.yaml
@@ -1,0 +1,2 @@
+head_model:
+  _target_: models.head

--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -268,6 +268,9 @@ def load_yaml_config(
     return config
 
 def unpack_profiles(config, config_path, profiles_keyword):
+    # Take profile information as an argument
+    # Raise error if no profiles are specified and there is no default
+
     profiles_dict = config[profiles_keyword]
     for default_yaml in profiles_dict:
         default_config = get_default_args_from_path(
@@ -356,25 +359,38 @@ def update_flat_config_types(flat_config: Config) -> Config:
         
 
 
-def get_command_line_config(arg_parser: argparse.ArgumentParser, config_argument_keyword: str="config") -> Tuple[str, List[str]]:
+def parse_initial_args(arg_parser: argparse.ArgumentParser,
+                            config_argument_keyword: str="config", 
+                            profiles_keyword: str = BASE_PROFILES_KEYWORD) -> Tuple[str, List[str]]:
     """
-    Check to see if the user specified an alternative config via the command line. If so,
-    return the path of that config, and the remaining arguments. Otherwise, return None
+    Check to see if the user specified a config or profile information via the command line. If so,
+    return the path of that config, any profiles information and the remaining arguments. Otherwise, return None
     and the remaining arguments.
 
     Args:
         arg_parser (argparse.ArgumentParser): The argparse object to add the config arg to.
         config_argument_keyword (str): Default keyword to accept new config path from the 
             command line.
+        profiles_keyword (str): Default keyword for profiles
     
     Returns:
         str: A string of the path to the alternate config.
+        str: The specified profile
+        List[str]: A list of the profile specifiers.
         List[str]: All remaining arguments.
     """
+
+    arg_parser.add_argument(f"profile", default=None, type=str)
     arg_parser.add_argument(f"--{config_argument_keyword}", default=None, type=str)
+    arg_parser.add_argument(f"--{profiles_keyword}", nargs="*", default=[], type=str)
+
     known_args, unknown_args = arg_parser.parse_known_args()
+    
+    profile = known_args.profile
+    profile_specifiers = vars(known_args)[profiles_keyword]
+    
     config_path = vars(known_args)[config_argument_keyword]
-    return config_path, unknown_args
+    return config_path, profile, profile_specifiers, unknown_args
 
 
 def config_to_nested_config(config: Config) -> Config:

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -63,7 +63,7 @@ def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) 
     """
     # Parse high-level arguments
     parser = argparse.ArgumentParser()    
-    config_dir_command_line, profile, profile_specifiers, remaining_args = parse_initial_args(parser)
+    config_dir_command_line, profile, profile_specifiers, temp_args = parse_initial_args(parser)
     
 
     # Find final config name and directory
@@ -80,12 +80,16 @@ def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) 
     def _parse_config(main: Callable):
         @functools.wraps(main)
         def _inner_function():
-            config = load_yaml_config(config_dir, config_name)
+            config = load_yaml_config(config_dir, config_name, profile, profile_specifiers)
 
             add_args_from_dict(parser, config)
 
-            args = parser.parse_args(remaining_args)
+            args = parser.parse_args()
             args = update_flat_config_types(args)
+
+            for temp_arg in temp_args:
+                del args[temp_arg]
+
             args = config_to_nested_config(args)
 
             return main(args)


### PR DESCRIPTION
Closes #31 

* I used `~` instead of `!` for specifying defaults as `!` is reserved for yaml syntax. 
* This does implement the subconfig behavior as it was less complex than expected.
* I ran all of the example files and created a new one for this behavior and all of those run error-free. However, there might be some super sneaky edge cases that no mortal could have considered.