### PR TITLE
Updated unlock to allow for mutiple unlocks and unlock nesting

### DIFF
--- a/example/multiple_unlocks_example/config1.yaml
+++ b/example/multiple_unlocks_example/config1.yaml
@@ -1,0 +1,6 @@
+?debug: true
+epochs: 128
+model:
+  _target_: main.MyModel
+  layer_size: 128
+  activation: relu

--- a/example/multiple_unlocks_example/config2.yaml
+++ b/example/multiple_unlocks_example/config2.yaml
@@ -1,0 +1,3 @@
+eval:
+  metric: rscore
+  logging_path: /path/for/logging

--- a/example/multiple_unlocks_example/main.py
+++ b/example/multiple_unlocks_example/main.py
@@ -1,0 +1,39 @@
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
+import skeletonkey
+
+class MyModel:
+    def __init__(self, layer_size: int, activation: str) -> None:
+        self.layer_size = layer_size
+        self.activation = activation
+
+@skeletonkey.unlock("config2.yaml")
+def evaluate(args):
+    print(args)
+    print("Metric: ", args.eval.metric)
+    print("Logging Path: ", args.eval.logging_path)
+    # Note: All the args from main are inaccessable from this args object and vice versa. 
+
+@skeletonkey.unlock("config1.yaml")
+def main(args):
+    print(args)
+    model = skeletonkey.instantiate(args.model)
+    print("Instantiate Function:")
+    print("Model layer size: ", model.layer_size)
+    print("Model activation: ", model.activation)
+    print("Number of Epochs: ", args.epochs)
+    print("Debug Flag: ", args.debug)
+
+    model2 = args.model.instantiate()
+    print("Instantiate Method:")
+    print("Model layer size: ", model2.layer_size)
+    print("Model activation: ", model2.activation)
+    print("Number of Epochs: ", args.epochs)
+    print("Debug Flag: ", args.debug)
+
+    evaluate()
+
+if __name__ == "__main__":  
+    main()

--- a/example/nested_unlocks_example/config1.yaml
+++ b/example/nested_unlocks_example/config1.yaml
@@ -1,0 +1,6 @@
+?debug: true
+epochs: 128
+model:
+  _target_: main.MyModel
+  layer_size: 128
+  activation: relu

--- a/example/nested_unlocks_example/config2.yaml
+++ b/example/nested_unlocks_example/config2.yaml
@@ -1,0 +1,4 @@
+epochs: 256
+eval:
+  metric: rscore
+  logging_path: /path/for/logging

--- a/example/nested_unlocks_example/main.py
+++ b/example/nested_unlocks_example/main.py
@@ -1,0 +1,35 @@
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
+import skeletonkey
+
+class MyModel:
+    def __init__(self, layer_size: int, activation: str) -> None:
+        self.layer_size = layer_size
+        self.activation = activation
+
+# Note: The last decorator applied (config1) will overwriute any matching keys in any previous configs (config2).
+@skeletonkey.unlock("config1.yaml")
+@skeletonkey.unlock("config2.yaml")
+def main(args):
+    print(args)
+    model = skeletonkey.instantiate(args.model)
+    print("Instantiate Function:")
+    print("Model layer size: ", model.layer_size)
+    print("Model activation: ", model.activation)
+    print("Number of Epochs: ", args.epochs)
+    print("Debug Flag: ", args.debug)
+
+    model2 = args.model.instantiate()
+    print("Instantiate Method:")
+    print("Model layer size: ", model2.layer_size)
+    print("Model activation: ", model2.activation)
+    print("Number of Epochs: ", args.epochs)
+    print("Debug Flag: ", args.debug)
+
+    print("Metric: ", args.eval.metric)
+    print("Logging Path: ", args.eval.logging_path)
+
+if __name__ == "__main__":  
+    main()

--- a/skeletonkey/instantiate.py
+++ b/skeletonkey/instantiate.py
@@ -42,13 +42,17 @@ def instantiate_partial(config, target_keyword=TARGET_KEYWORD,_instantiate_recur
     Returns:
         Any: An instance of functools.partial of the specified class.
     """
-    obj_kwargs = vars(config).copy()
+    if not isinstance(config, dict):
+        obj_kwargs = config.to_dict().copy()
+    else: 
+        obj_kwargs = config.copy()
+
     class_obj = import_target(obj_kwargs[target_keyword])
     del obj_kwargs[target_keyword]
 
     if _instantiate_recursive:
         for k, v in obj_kwargs.items():
-            if isinstance(v, type(config)) and (target_keyword in vars(v)):
+            if isinstance(v, dict) and (target_keyword in v):
                 obj_kwargs[k] = instantiate_partial(v)
 
     obj_kwargs.update(kwargs)
@@ -80,13 +84,17 @@ def instantiate(config, target_keyword=TARGET_KEYWORD, _instantiate_recursive=Tr
     Raises:
         TypeError: If the class is missing specific parameters.
     """
-    obj_kwargs = vars(config).copy()
+    if not isinstance(config, dict):
+        obj_kwargs = config.to_dict().copy()
+    else: 
+        obj_kwargs = config.copy()
+
     class_obj = import_target(obj_kwargs[target_keyword])
     del obj_kwargs[target_keyword]
 
     if _instantiate_recursive:
         for k, v in obj_kwargs.items():
-            if isinstance(v, type(config)) and (target_keyword in vars(v)):
+            if isinstance(v, dict) and (target_keyword in v):
                 obj_kwargs[k] = instantiate(v)
 
     obj_kwargs.update(kwargs)
@@ -152,7 +160,7 @@ def fetch(config, target_keyword=TARGET_KEYWORD):
         Any: The value associated with the specified "_target_".
     """
 
-    obj_kwargs = vars(config).copy()
+    obj_kwargs = config.to_dict().copy()
     obj = import_target(obj_kwargs[target_keyword])
 
     return obj


### PR DESCRIPTION
Previously, the unlock function did not support multiple unlocks with different configs within a program. Additionally, you could not nest unlock decorators if you wanted to combine multiple configs into one config object. With this change, the unlock function can now do both.

If a user has two functions, each with a different @unlock call, and each pointing to a different config, they can do that. Each Config object created will only have the keys from the YAML file specified in the unlock. These keys can be overwritten from the command line as usual. However, this means that a user can now specify arbitrary keys from the command line without causing an error. These keys go unparsed, and if a user tries to access these unparsed keys that do not exist in a YAML file, they will get an attribute error indicating that they did specify this key from the command line, but they need it to be in the YAML config. Because I am storing the unparsed keys in the config object as a private variable, I created a "to_dict" method for the Config class that controls how the config object is converted to a dictionary, which means that this private attribute is excluded in the conversion. This "to_dict" method was used in place of using the 'vars' function within the instantiate function family so that they do not attempt to add private attributes from the config class into the object the function is attempting to instantiate. Additionally, if a user tries to specify a config from the command line when there are multiple unlocks, they are given a warning that tells them that all the configs have been overwritten with this config. In the future, this can be changed to potentially only overwriting the config from the first call of unlock or some other behavior.

Additionally, I changed the unlock function in a way that allows nesting. This means that a user can add multiple unlock decorators to a single function. The keys from the last decorator applied will overwrite any matching keys from the previous unlock.

Future additions may include allowing a user to specify a prefix in an unlock, meaning that they can nest unlocks with the same key names without having them overwritten. Additionally, with the prefix, it would potentially allow for separate unlocks to be changed via the command line (i.e., the prefix is an unlock identifier). Also, the unlock can be changed so that the user can specify skeleton key keywords like "keyring."

Overall, I think this expands the use cases for skeleton key, allowing for more complex behavior.