### PR TITLE
Added options to overwrite skeleton keywords from unlock. Added the a…

### DIFF
--- a/example/multiple_unlocks_example/main.py
+++ b/example/multiple_unlocks_example/main.py
@@ -9,14 +9,14 @@ class MyModel:
         self.layer_size = layer_size
         self.activation = activation
 
-@skeletonkey.unlock("config2.yaml")
+@skeletonkey.unlock("config2.yaml", config_argument_keyword="config2")
 def evaluate(args):
     print(args)
     print("Metric: ", args.eval.metric)
     print("Logging Path: ", args.eval.logging_path)
     # Note: All the args from main are inaccessable from this args object and vice versa. 
 
-@skeletonkey.unlock("config1.yaml")
+@skeletonkey.unlock("config1.yaml", config_argument_keyword="config1")
 def main(args):
     print(args)
     model = skeletonkey.instantiate(args.model)

--- a/example/nested_unlocks_example/config2.yaml
+++ b/example/nested_unlocks_example/config2.yaml
@@ -1,4 +1,3 @@
 epochs: 256
-eval:
-  metric: rscore
-  logging_path: /path/for/logging
+metric: rscore
+logging_path: /path/for/logging

--- a/example/nested_unlocks_example/main.py
+++ b/example/nested_unlocks_example/main.py
@@ -11,7 +11,7 @@ class MyModel:
 
 # Note: The last decorator applied (config1) will overwriute any matching keys in any previous configs (config2).
 @skeletonkey.unlock("config1.yaml")
-@skeletonkey.unlock("config2.yaml")
+@skeletonkey.unlock("config2.yaml", config_argument_keyword="config2", prefix="eval")
 def main(args):
     print(args)
     model = skeletonkey.instantiate(args.model)

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -15,6 +15,10 @@ from .config import (
     Config,
 )
 
+BASE_PROFILES_KEYWORD: str = "profiles"
+BASE_COLLECTION_KEYWORD: str = "keyring"
+BASE_CL_CONFIG_KEYWORD: str = "config"
+
 
 def get_config_dir_path(config_path: str) -> str:
     """
@@ -47,7 +51,14 @@ def get_config_dir_path(config_path: str) -> str:
     return config_path
 
 
-def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) -> Callable:
+def unlock(
+    config_name: Optional[str] = None, 
+    config_dir: Optional[str] = None,
+    prefix: Optional[str] = None,
+    config_argument_keyword: Optional[str] = BASE_CL_CONFIG_KEYWORD,
+    profiles_keyword: Optional[str] = BASE_PROFILES_KEYWORD,
+    collection_keyword: Optional[str] = BASE_COLLECTION_KEYWORD,
+) -> Callable:
     """
     Create a decorator for parsing and injecting configuration arguments into a
     main function from a YAML file.
@@ -63,10 +74,14 @@ def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) 
                   main function.
     """
     # Parse high-level arguments
-    parser = argparse.ArgumentParser()    
-    config_dir_command_line, profile, profile_specifiers, temp_args = parse_initial_args(parser)
+    parser = argparse.ArgumentParser(allow_abbrev=False)    
+    initial_args = parse_initial_args(
+        arg_parser=parser, 
+        config_argument_keyword=config_argument_keyword, 
+        profiles_keyword=profiles_keyword,
+    )
+    config_dir_command_line, profile, profile_specifiers, temp_args = initial_args
     
-
     # Find final config name and directory
     if config_dir_command_line is not None:
         config_name = os.path.abspath(config_dir_command_line)
@@ -74,10 +89,13 @@ def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) 
 
         # If they have more than one unlock, warn user than the command-line config will
         # overwrite all the configs for all unlocks.
-        if hasattr(unlock, "_command_line_unlock"):
-            warnings.warn("Multiple @unlock decorators are present. The command line configurations will be used for all @unlock calls.")
-        else:
-            setattr(unlock, "_command_line_unlock", True)
+        if not hasattr(unlock, "_command_line_unlock"):
+            setattr(unlock, "_command_line_unlock", {})
+            unlock._command_line_unlock[config_argument_keyword] = unlock._command_line_unlock.get(config_argument_keyword, 0) + 1
+
+        if unlock._command_line_unlock.get(config_argument_keyword, 0) > 1:
+            warnings.warn(f"Multiple @unlock decorators are present with the same command line keyword " 
+                          + f"'{config_argument_keyword}'. The command line configurations will be used for all @unlock calls.")
 
     if config_name is not None:
         config_dir = get_config_dir_path(os.path.dirname(config_name))
@@ -89,9 +107,20 @@ def unlock(config_name: Optional[str] = None, config_dir: Optional[str] = None) 
     def _parse_config(main: Callable):
         @functools.wraps(main)
         def _inner_function(config: Config=None):
-            config_dict = load_yaml_config(config_dir, config_name, profile, profile_specifiers)
+            config_dict = load_yaml_config(
+                config_path=config_dir, 
+                config_name=config_name, 
+                profile=profile, 
+                profile_specifiers=profile_specifiers,
+                profiles_keyword=profiles_keyword,
+                collection_keyword=collection_keyword
+            )
 
-            add_args_from_dict(parser, config_dict)
+            add_args_from_dict(
+                arg_parser=parser, 
+                config_dict=config_dict, 
+                prefix=prefix + "." if prefix is not None else "",
+            )
 
             args, unparsed_args = parser.parse_known_args()
             unparsed_args = [arg.strip("--") for arg in unparsed_args]


### PR DESCRIPTION
…bility to prepend a prefix (creating a nested config) to allow for easier use of nested unlocks. Removed positional use of profiles (could be added back later, the removed implementation caused many issues when dealing with unparsed arguments.