### PR TITLE
Config return type

### DIFF
--- a/example/basic_example/main.py
+++ b/example/basic_example/main.py
@@ -1,5 +1,5 @@
 # Adds the local skeletonkey source code to path, so that version is imported
-import os, sys
+import os, sys, pprint
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
 
 import skeletonkey
@@ -25,6 +25,8 @@ def main(args):
     print("Model activation: ", model.activation)
     print("Number of Epochs: ", args.epochs)
     print("Debug Flag: ", args.debug)   
+
+    pprint.pp(args.to_dict())
 
 if __name__ == "__main__":  
     main()

--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -123,7 +123,7 @@ class Config():
 
         return s
     
-    def to_dict(self) -> "Config":
+    def to_dict(self) -> dict:
         return self._to_dict(self)
 
     def _to_dict(self, subspace: "Config"):


### PR DESCRIPTION
For some reason when you type hint a string like "Config", it makes that function not show up in the __dir__ of the class. It also just didnt make sense for the function `to_dict()` to return a type of "Config". You can now call this function and it will return a dictionary.