### PR TITLE
Config interpolation

### DIFF
--- a/example/interpolate_example/config.yaml
+++ b/example/interpolate_example/config.yaml
@@ -1,0 +1,9 @@
+model:
+  _instance_: main.MyModel
+  activation: relu
+  debug: False
+
+dataloader:
+  _instance_: main.MyDataLoader
+  batch_size: 32
+  debug: ${model.debug}

--- a/example/interpolate_example/main.py
+++ b/example/interpolate_example/main.py
@@ -1,0 +1,23 @@
+# Adds the local skeletonkey source code to path, so that version is imported
+import os, sys, pprint
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+
+import skeletonkey
+
+class MyModel:
+    def __init__(self, activation: str, debug: bool) -> None:
+        self.activation = activation
+        self.debug = debug
+
+class MyDataloader:
+    def __init__(self, batch_size: int, debug: bool) -> None:
+        self.batch_size = batch_size
+        self.debug = debug
+
+
+@skeletonkey.unlock("config.yaml")
+def main(args):
+    print(args)
+
+if __name__ == "__main__":  
+    main()

--- a/skeletonkey/config.py
+++ b/skeletonkey/config.py
@@ -33,7 +33,7 @@ class Config():
             it is expected that the keys are in dot notation.
         """
         if not isinstance(update_config, Config):
-            update_config = config_to_nested_config(Config(update_config))
+            update_config = Config(dict_to_nested_dict(update_config))
         self._update_from_config(update_config)
         return self
 
@@ -489,7 +489,7 @@ def add_args_from_dict(
                     f"--{prefix}{key}", default=value
                 )
 
-def namespace_to_config(flat_config: argparse.Namespace) -> Config:
+def flat_namespace_to_dict(flat_config: argparse.Namespace) -> Config:
     """
     Given a flat namespace containing some string values, parse those string values as if they were
     yaml arguemnts into the corresponding python type and return an updated config.
@@ -497,10 +497,10 @@ def namespace_to_config(flat_config: argparse.Namespace) -> Config:
     Args:
         config (argparse.Namespace): The flat Config whose values should be parsed
     """
-    return Config({
+    return {
         key: yaml.safe_load(value) if isinstance(value, str) else value
         for key, value in vars(flat_config).items()
-    })
+    }
 
 
 def parse_initial_args(
@@ -541,19 +541,18 @@ def parse_initial_args(
     return config_path, profile, profile_specifiers, [config_argument_keyword, "_profile_specifiers"]
 
 
-def config_to_nested_config(config: Config, unparsed_args: List[str]=None) -> Config:
+def dict_to_nested_dict(config: dict) -> dict:
     """
-    Convert an Config object with 'key1.keyn' formatted keys into a nested Config object.
+    Convert a dict with 'key1.keyn' formatted keys into a nested dictionary.
 
     Args:
-        config (Config): The Config object to be converted.
+        config (dict): The Config object to be converted.
 
     Returns:
-        Config: A nested Config representation of the input Config object.
-        unparsed_args (List[str]): Arguments passed from the command line not specified in the yaml config. 
+        dict: A nested dictionarty representation of the input dictionary.
     """
     nested_dict = {}
-    for key, value in vars(config).items():
+    for key, value in config.items():
         keys = key.split(".")
         current_dict = nested_dict
         for sub_key in keys[:-1]:
@@ -562,4 +561,4 @@ def config_to_nested_config(config: Config, unparsed_args: List[str]=None) -> Co
             current_dict = current_dict[sub_key]
         current_dict[keys[-1]] = value
 
-    return Config(nested_dict, unparsed_args)
+    return nested_dict

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional
 import warnings
 
 from .config import (
+    interpolate_config,
     parse_initial_args,
     load_yaml_config,
     add_args_from_dict,
@@ -130,6 +131,8 @@ def unlock(
                 del args[temp_arg]
 
             args = dict_to_nested_dict(args)
+            
+            interpolate_config(args)
 
             args = Config(args, unparsed_args)
             if config is not None:

--- a/skeletonkey/core.py
+++ b/skeletonkey/core.py
@@ -10,8 +10,8 @@ from .config import (
     load_yaml_config,
     add_args_from_dict,
     add_yaml_extension,
-    namespace_to_config,
-    config_to_nested_config,
+    flat_namespace_to_dict,
+    dict_to_nested_dict,
     Config,
 )
 
@@ -124,13 +124,14 @@ def unlock(
 
             args, unparsed_args = parser.parse_known_args()
             unparsed_args = [arg.strip("--") for arg in unparsed_args]
-            args = namespace_to_config(args)
+            args = flat_namespace_to_dict(args)
 
             for temp_arg in temp_args:
                 del args[temp_arg]
 
-            args = config_to_nested_config(args, unparsed_args)
-            
+            args = dict_to_nested_dict(args)
+
+            args = Config(args, unparsed_args)
             if config is not None:
                 args.update(config)
 


### PR DESCRIPTION
I decided to change the indication of an interpolation keyword from `$key$` as we discussed to `${key}`. Copilot suggested it while  I was writing it, so I looked into it, wondering if it was perhaps a piece of yaml syntax. It is not, but it does seem that it is the way that some other libraries do substitutions in yaml. If it is a pseudo-standard way of indicating that, I think we might as well use it.

In the commit, 9071742b, I changed some function names and rearranged some functionality. I did this in order to delay the point at which the config dictionary becomes a config object behind the scene. I did this partly because the interpolation was easier to do on a dictionary than a config, but also because it seemed like a more striaghtforward way of organizing the unlock process
It might be the case that such a change could be its own pull request. However, adding interpolation without this would have been more difficult.
